### PR TITLE
Message reaction

### DIFF
--- a/client.go
+++ b/client.go
@@ -330,7 +330,7 @@ func (c *Conn) SkypeRegistrationTokenProvider(skypeToken string) (err error) {
 		"BehaviorOverride": "redirectAs404",
 	}
 	data := map[string]interface{}{
-		"endpointFeatures": "Agent",
+		"endpointFeatures": "Agent,MessageProperties",
 	}
 	params, _ := json.Marshal(data)
 	registrationTokenStr, location, err := req.HttpPostRegistrationToken(c.LoginInfo.LocationHost+"/v1/users/"+DEFAULT_USER+"/endpoints", string(params), header)

--- a/conversation.go
+++ b/conversation.go
@@ -114,6 +114,17 @@ type ShareLink struct {
 	Url string `json:"url"`
 }
 
+type EmotionUser struct {
+	Mri   string  `json:"mri"`
+	Time  int     `json:"time"`
+	Value string  `json:"value"`
+}
+
+type Emotion struct {
+	Key string `json:"key"`
+	Users []EmotionUser
+}
+
 type Resource struct {
 	ConversationLink      string        `json:"conversationLink"`
 	Type                  string        `json:"type"`
@@ -147,6 +158,7 @@ type Resource struct {
 	Properties    struct {
 		UrlPreviews  string   `json:"urlpreviews"`
 		Capabilities []string `json:"capabilities"`
+		Emotions     []Emotion `json:"emotions"`
 	} `json:"properties"`
 }
 

--- a/conversation.go
+++ b/conversation.go
@@ -132,7 +132,7 @@ type Resource struct {
 	AckRequired           string        `json:"ackrequired"`
 	ContentType           string        `json:"contenttype"`
 	IsVideoCall           string        `json:"isVideoCall"` // "FALSE|TRUE"
-	IsActive              bool          `json:"isactive"`
+	// IsActive              bool          `json:"isactive"`
 	ThreadTopic           string        `json:"threadtopic"`
 	ContentFormat         string        `json:"contentformat"`
 	ETag                  string        `json:"eTag"`

--- a/handler.go
+++ b/handler.go
@@ -144,7 +144,7 @@ type ChatUpdateHandler interface {
 
 func (c *Conn) handleWithCustomHandlers(message Conversation, handlers []Handler) {
 	//switch m := message.(type) {
-	if message.ResourceType == "NewMessage" {
+	if message.ResourceType == "NewMessage" || message.ResourceType == "MessageUpdate" {
 		//resource := Resource{}
 		//resource, ok := (message.Resource).(Resource)
 		//if !ok {


### PR DESCRIPTION
This adds support for (currently one-way) message reactions.

Skype sends message reactions as part of the long-poll http endpoint if the features include `MessageProperties`. The reaction is a `MessageUpdate` with the following `properties`
```json
{
  "id":1003,
  "type":"EventMessage",
  "resourceType":"MessageUpdate",
  "resourceLink":"https://azscus1-client-s.gateway.messenger.live.com/v1/users/ME/conversations/8:USERNAME/messages/MESSAGEID",
  "id":"MESSAGEID",
  "properties":{
    "emotions":[
      {
        "key":"reactionsConsumptionHorizon",
        "users":[{"mri":"8:ulrichyannick","time":1735050131497,"value":"1735050131291"}]
      },{
        "key":"party",
        "users":[{"mri":"8:USERNAME","time":1735050585759,"value":"1735050585305"}]
      }
    ]
  }
}
```
It should be fairly easy to add PUTing of reactions as well by sending
```shell
curl 'https://msgapi.teams.live.com/v1/users/ME/conversations/8%3AUSERNAME/messages/MESSAGEID/properties?name=emotions'  -X PUT --data-raw '{"emotions":"{\"key\":\"festiveparty\",\"value\":\"1735050028329\"}"}'
```
Integration into [kelaresg/go-skype-bridge](https://github.com/kelaresg/go-skype-bridge) is still WIP.

Let me know what you think 😊